### PR TITLE
Use nonroot distroless variant

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Set up QEMU

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   "NVD-check":
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /app/
 RUN make
 RUN make opentelemetry-javaagent.jar
 
-FROM gcr.io/distroless/java21-debian12
+FROM gcr.io/distroless/java21-debian12:nonroot
 COPY --from=builder /app/target/eduhub-validator-service.jar /eduhub-validator-service.jar
 COPY --from=builder /app/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ curl -v 'http://localhost:3002/configstatus/demo04.test.surfeduhub.nl'
 curl -v -X POST 'http://localhost:3002/jobs/paths/demo04.test.surfeduhub.nl'
 ```
 
+The image build is *nonroot* variant of *distroless* Debian which runs as:
+
+- *user*: `nonroot` (uid=65532)
+- *group*: `nonroot` (guid=65532)
+
 ## Run locally
 
 ```bash


### PR DESCRIPTION
The services will run as:

  user: nonroot (uid=65532)
  group: nonroot (guid=65532)

I can't find proper documentation but see also:

- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/BUILD.bazel#L123
- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/variables.bzl#L18