### PR TITLE
Make the service support multiple OEAPI versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Use the validator to validate the endpoint and generate a report.
 
 ### Fetch Status
 
-Load the current status as json. Fields include job-status (pending, finished or failed), endpoint-id, profile, 
-pending-at and finished-at, with ISO-8601 timestamp format. 
+Load the current status as json. Fields include job-status (pending, finished or failed), endpoint-id, profile,
+pending-at and finished-at, with ISO-8601 timestamp format.
 
 `GET /status/{uuid}`
 
@@ -74,12 +74,13 @@ GATEWAY_BASIC_AUTH_PASS             Password for gateway
 SURF_CONEXT_CLIENT_ID               SurfCONEXT client id for validation service
 SURF_CONEXT_CLIENT_SECRET           SurfCONEXT client secret for validation service
 SURF_CONEXT_INTROSPECTION_ENDPOINT  SurfCONEXT introspection endpoint
-ALLOWED_CLIENT_IDS                  Comma separated list of allowed SurfCONEXT client ids. 
+ALLOWED_CLIENT_IDS                  Comma separated list of allowed SurfCONEXT client ids.
 MAX_TOTAL_REQUESTS                  Maximum number of requests that validator is allowed to make before raising an error
 CHECK_ENDPOINT_PATH                 Default path used when checking `/configstatus/{endpointId}` (defaults to `/courses`).
 OOAPI_VERSION                       Ooapi version to pass through to gateway
 SERVER_PORT                         Starts the app server on this port
 REDIS_URI                           URI to redis
+VALIDATOR_INSTANCE_NAME             Unique name for the validator instance - needed when multiple validator services share a redis instance
 JOB_STATUS_EXPIRY_SECONDS           Number of seconds before job status in Redis expires
 SPIDER_TIMEOUT_MILLIS               Maximum number of milliseconds before spider timeout.
 VALIDATOR_SERVICE_ROOT_URL          The root url of the web endpoint, used to generate a url to a status view. This url is included in the json output after starting a validation job as "web-url".

--- a/deps.edn
+++ b/deps.edn
@@ -30,8 +30,7 @@
          nl.jomco/clj-http-status-codes {:mvn/version "0.2"}
          nl.jomco/envopts               {:mvn/version "0.0.7"}
          nl.surfnet/eduhub-validator    {:git/url "https://github.com/SURFnet/eduhub-validator"
-                                         :git/sha "9d9d68db37734e5c356a40773f3939cdfd427a7b"
-                                         :git/tag "v1.1.0"}
+                                         :git/sha "6915d55ec3461fb84c81d92e38b6b6a541193795"}
          nl.jomco/with-resources        {:mvn/version "0.1.2"}}
  :aliases
  {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}}

--- a/src/nl/surf/eduhub/validator/service/api.clj
+++ b/src/nl/surf/eduhub/validator/service/api.clj
@@ -101,8 +101,8 @@
   (let [allowed-client-id-set (set (string/split allowed-client-ids #","))
         auth-opts             {:auth-disabled (boolean auth-disabled)}]
     (-> (compojure.core/routes
-         (GET "/configstatus/:endpoint-id" [endpoint-id path]
-            (checker/check-endpoint endpoint-id path config))
+         (GET "/configstatus/:endpoint-id" [endpoint-id path oeapi-version]
+           (checker/check-endpoint endpoint-id path (or oeapi-version "5") config))
          (POST "/jobs/paths/:endpoint-id" [endpoint-id profile]
             (jobs-client/enqueue-validation endpoint-id profile config)))
         (auth/wrap-authentication introspection-endpoint-url introspection-basic-auth allowed-client-id-set auth-opts)

--- a/src/nl/surf/eduhub/validator/service/checker.clj
+++ b/src/nl/surf/eduhub/validator/service/checker.clj
@@ -26,9 +26,9 @@
 
 ;; The endpoint checker from phase 1. This connects to an endpoint via the gateway and checks if it receives
 ;; a valid response.
-(defn check-endpoint [endpoint-id custom-path config]
+(defn check-endpoint [endpoint-id custom-path oeapi-version config]
   (try
-    (let [{:keys [status body]} (validate/check-endpoint endpoint-id custom-path config)]
+    (let [{:keys [status body]} (validate/check-endpoint endpoint-id custom-path oeapi-version config)]
       ;; If the client credentials for the validator are incorrect, the wrap-authentication
       ;; middleware has already returned 401 forbidden and execution doesn't get here.
       (handle-check-endpoint-response status body endpoint-id))

--- a/src/nl/surf/eduhub/validator/service/config.clj
+++ b/src/nl/surf/eduhub/validator/service/config.clj
@@ -55,6 +55,9 @@
                                         :in [:expiry-seconds]]
    :validator-service-root-url         ["Root url for the web view; does not include path" :str
                                         :in [:root-url]]
+   :validator-instance-name            ["Unique name for the validator service instance" :str
+                                        :default "shared-validator-service"
+                                        :in [:validator-instance-name]]
    :spider-timeout-millis              ["Maximum number of milliseconds before spider timeout." :int
                                         :default 3600000
                                         :in [:spider-timeout-millis]]})
@@ -83,14 +86,17 @@
   [[config errs]]
   (if errs
     [config errs]
-    (let [goose-conn-opts {:url (get-in config [:redis-conn :spec :uri])}]
+    (let [goose-conn-opts {:url (get-in config [:redis-conn :spec :uri])}
+          queue-id (get-in config [:validator-instance-name])]
       [(assoc config
               :goose-worker-opts (-> goose.worker/default-opts
-                                     (assoc :broker (redis.broker/new-consumer goose-conn-opts)))
+                                     (assoc :broker (redis.broker/new-consumer goose-conn-opts)
+                                            :queue queue-id))
               :goose-client-opts (-> goose.client/default-opts
                                      (assoc :retry-opts (assoc goose.retry/default-opts
                                                                :error-handler-fn-sym 'nl.surf.eduhub.validator.service.jobs.client/job-error-handler)
-                                            :broker (redis.broker/new-producer goose-conn-opts))))])))
+                                            :broker (redis.broker/new-producer goose-conn-opts)
+                                            :queue queue-id)))])))
 
 (defn load-config-from-env [env-map]
   (-> (reduce file-secret-loader-reducer env-map (keys opt-specs))

--- a/src/nl/surf/eduhub/validator/service/config.clj
+++ b/src/nl/surf/eduhub/validator/service/config.clj
@@ -55,8 +55,6 @@
                                         :in [:expiry-seconds]]
    :validator-service-root-url         ["Root url for the web view; does not include path" :str
                                         :in [:root-url]]
-   :ooapi-version                      ["Ooapi version to pass through to gateway" :str
-                                        :in [:ooapi-version]]
    :spider-timeout-millis              ["Maximum number of milliseconds before spider timeout." :int
                                         :default 3600000
                                         :in [:spider-timeout-millis]]})

--- a/src/nl/surf/eduhub/validator/service/jobs/client.clj
+++ b/src/nl/surf/eduhub/validator/service/jobs/client.clj
@@ -10,13 +10,12 @@
 
 ;; Enqueue the validate-endpoint call in the worker queue.
 (defn enqueue-validation
-  [endpoint-id profile {:keys [redis-conn gateway-basic-auth gateway-url ooapi-version max-total-requests root-url goose-client-opts] :as _config}]
+  [endpoint-id profile {:keys [redis-conn gateway-basic-auth gateway-url max-total-requests root-url goose-client-opts] :as _config}]
   (let [uuid (str (UUID/randomUUID))
         prof (or profile "ooapi")
         opts {:basic-auth         gateway-basic-auth
               :base-url           gateway-url
               :max-total-requests max-total-requests
-              :ooapi-version      ooapi-version
               :profile            prof}]
     (status/set-status-fields redis-conn uuid "pending" {:endpoint-id endpoint-id, :profile prof} nil)
     (c/perform-async goose-client-opts `worker/validate-endpoint endpoint-id uuid opts)

--- a/src/nl/surf/eduhub/validator/service/jobs/client.clj
+++ b/src/nl/surf/eduhub/validator/service/jobs/client.clj
@@ -6,17 +6,29 @@
   (:import [java.util UUID]))
 
 (defn job-error-handler [_cfg _job ex]
-  (log/error ex "Error in job"))
+  ;; Do not log the complete Goose job: its arguments include gateway credentials.
+  (log/error ex "Goose failed while processing a queued validation job"))
 
 ;; Enqueue the validate-endpoint call in the worker queue.
 (defn enqueue-validation
-  [endpoint-id profile {:keys [redis-conn gateway-basic-auth gateway-url max-total-requests root-url goose-client-opts] :as _config}]
+  [endpoint-id profile {:keys [redis-conn gateway-basic-auth gateway-url max-total-requests root-url goose-client-opts expiry-seconds] :as _config}]
   (let [uuid (str (UUID/randomUUID))
         prof (or profile "ooapi")
         opts {:basic-auth         gateway-basic-auth
               :base-url           gateway-url
               :max-total-requests max-total-requests
               :profile            prof}]
+    (log/infof "Creating validation job uuid=%s endpoint-id=%s profile=%s" uuid endpoint-id prof)
     (status/set-status-fields redis-conn uuid "pending" {:endpoint-id endpoint-id, :profile prof} nil)
-    (c/perform-async goose-client-opts `worker/validate-endpoint endpoint-id uuid opts)
-    {:status 200 :body {:job-status "pending" :uuid uuid, :web-url (str root-url "/view/status/" uuid)}}))
+    (log/infof "Stored pending validation status uuid=%s; enqueueing job" uuid)
+    (try
+      (c/perform-async goose-client-opts `worker/validate-endpoint endpoint-id uuid opts)
+      (log/infof "Enqueued validation job uuid=%s endpoint-id=%s profile=%s" uuid endpoint-id prof)
+      {:status 200 :body {:job-status "pending" :uuid uuid, :web-url (str root-url "/view/status/" uuid)}}
+      (catch Exception ex
+        (log/error ex (format "Failed to enqueue validation job uuid=%s endpoint-id=%s profile=%s"
+                              uuid endpoint-id prof))
+        (status/set-status-fields redis-conn uuid "failed"
+                                  {"error" "Failed to enqueue validation job"}
+                                  expiry-seconds)
+        (throw ex)))))

--- a/src/nl/surf/eduhub/validator/service/jobs/worker.clj
+++ b/src/nl/surf/eduhub/validator/service/jobs/worker.clj
@@ -37,7 +37,7 @@
 
 ;; Runs the validate-endpoint function
 ;; and updates the values in the job status.
-;; opts should contain: basic-auth ooapi-version base-url profile
+;; opts should contain: basic-auth base-url profile
 
 (defn validate-endpoint
   [endpoint-id uuid opts]

--- a/src/nl/surf/eduhub/validator/service/jobs/worker.clj
+++ b/src/nl/surf/eduhub/validator/service/jobs/worker.clj
@@ -28,6 +28,7 @@
   the system configuration that was used to start the worker
   resource."
   [{:keys [goose-worker-opts] :as config}]
+  (log/info "Starting Goose validation worker")
   (-> goose-worker-opts
       (assoc :middlewares (wrap-worker-config config))
       goose.worker/start
@@ -41,13 +42,30 @@
 
 (defn validate-endpoint
   [endpoint-id uuid opts]
-  (let [{:keys [redis-conn expiry-seconds]} *config*]
-    (assert redis-conn)
+  (let [started-at (System/nanoTime)
+        profile    (:profile opts)]
+    (log/infof "Worker received validation job uuid=%s endpoint-id=%s profile=%s"
+               uuid endpoint-id profile)
     (try
-      (let [html (validate/validate-endpoint endpoint-id opts)]
-        ;; assuming everything went ok, save html in status, update status and set expiry to value configured in ENV
-        (status/set-status-fields redis-conn uuid "finished" {"html-report" html} expiry-seconds))
+      (let [{:keys [redis-conn expiry-seconds]} *config*]
+        (when-not redis-conn
+          (throw (ex-info "Worker Redis connection is not configured" {})))
+        (log/infof "Starting endpoint validation uuid=%s endpoint-id=%s profile=%s"
+                   uuid endpoint-id profile)
+        (let [html (validate/validate-endpoint endpoint-id opts)]
+          ;; assuming everything went ok, save html in status, update status and set expiry to value configured in ENV
+          (status/set-status-fields redis-conn uuid "finished" {"html-report" html} expiry-seconds)
+          (log/infof "Finished validation job uuid=%s endpoint-id=%s profile=%s duration-ms=%d"
+                     uuid endpoint-id profile
+                     (long (/ (- (System/nanoTime) started-at) 1000000)))))
       (catch Exception ex
-        ;; otherwise set status to error, include error message and also set expiry
-        (log/error ex "Validate endpoint threw an exception")
-        (status/set-status-fields redis-conn uuid "failed" {"error" (str ex)} expiry-seconds)))))
+        (log/error ex (format "Validation job failed uuid=%s endpoint-id=%s profile=%s duration-ms=%d"
+                              uuid endpoint-id profile
+                              (long (/ (- (System/nanoTime) started-at) 1000000))))
+        ;; Config/Redis failures cannot always be persisted, so protect this update and
+        ;; retain the original exception in the logs.
+        (when-let [redis-conn (:redis-conn *config*)]
+          (try
+            (status/set-status-fields redis-conn uuid "failed" {"error" (str ex)} (:expiry-seconds *config*))
+            (catch Exception status-ex
+              (log/error status-ex (format "Could not store failed status for validation job uuid=%s" uuid)))))))))

--- a/src/nl/surf/eduhub/validator/service/jobs/worker.clj
+++ b/src/nl/surf/eduhub/validator/service/jobs/worker.clj
@@ -28,7 +28,9 @@
   the system configuration that was used to start the worker
   resource."
   [{:keys [goose-worker-opts] :as config}]
-  (log/info "Starting Goose validation worker")
+  (log/infof "Starting Goose validation worker queue=%s threads=%s"
+             (:queue goose-worker-opts)
+             (:threads goose-worker-opts))
   (-> goose-worker-opts
       (assoc :middlewares (wrap-worker-config config))
       goose.worker/start

--- a/src/nl/surf/eduhub/validator/service/validate.clj
+++ b/src/nl/surf/eduhub/validator/service/validate.clj
@@ -33,7 +33,7 @@
   (let [path     (or custom-path check-endpoint-path "courses")
         url      (str gateway-url (if (.endsWith gateway-url "/") "" "/") (if (.startsWith path "/") (subs path 1) path))
         opts     {:headers    {"x-route"             (str "endpoint=" endpoint-id)
-                               "accept"              (if (= 5 oeapi-version)
+                               "accept"              (if (= "5" oeapi-version)
                                                        (str "application/json; version=" oeapi-version)
                                                        (str "application/vnd.oeapi+json;version=" oeapi-version))
                                "x-envelope-response" "true"}

--- a/src/nl/surf/eduhub/validator/service/validate.clj
+++ b/src/nl/surf/eduhub/validator/service/validate.clj
@@ -28,12 +28,14 @@
 ;; Validates whether the endpoint is working and reachable at all.
 (defn check-endpoint
   "Performs a synchronous validation via the eduhub-validator"
-  [endpoint-id custom-path {:keys [gateway-url gateway-basic-auth ooapi-version check-endpoint-path] :as _config}]
+  [endpoint-id custom-path oeapi-version {:keys [gateway-url gateway-basic-auth check-endpoint-path] :as _config}]
   {:pre [gateway-url]}
   (let [path     (or custom-path check-endpoint-path "courses")
         url      (str gateway-url (if (.endsWith gateway-url "/") "" "/") (if (.startsWith path "/") (subs path 1) path))
         opts     {:headers    {"x-route"             (str "endpoint=" endpoint-id)
-                               "accept"              (str "application/json; version=" ooapi-version)
+                               "accept"              (if (= 5 oeapi-version)
+                                                       (str "application/json; version=" oeapi-version)
+                                                       (str "application/vnd.oeapi+json;version=" oeapi-version))
                                "x-envelope-response" "true"}
                   :basic-auth gateway-basic-auth
                   :throw      false}
@@ -45,8 +47,8 @@
 ;; Returns the generated HTML report.
 (defn validate-endpoint
   "Returns the HTML validation report as a String."
-  [endpoint-id {:keys [basic-auth ooapi-version max-total-requests base-url profile spider-timeout-millis] :as opts}]
-  {:pre [endpoint-id basic-auth ooapi-version base-url profile]}
+  [endpoint-id {:keys [basic-auth max-total-requests base-url profile spider-timeout-millis] :as opts}]
+  {:pre [endpoint-id basic-auth base-url profile]}
   (let [report-file       (File/createTempFile "report" ".html")
         report-path       (.getAbsolutePath report-file)
         observations-file (File/createTempFile "observations" ".edn")
@@ -56,7 +58,6 @@
                            :max-total-requests         max-total-requests,
                            :report-path                report-path,
                            :headers                    {:x-route             (str "endpoint=" endpoint-id),
-                                                        :accept              (str "application/json; version=" ooapi-version),
                                                         :x-envelope-response "false"},
                            :no-spider?                 false,
                            :max-requests-per-operation ##Inf,

--- a/test/nl/surf/eduhub/validator/service/checker_test.clj
+++ b/test/nl/surf/eduhub/validator/service/checker_test.clj
@@ -29,7 +29,7 @@
   (with-redefs [http/request (fn [_]
                                (update gateway-response
                                        :body json/write-str))]
-    (checker/check-endpoint endpoint-id nil {:gateway-url "http://localhost"})))
+    (checker/check-endpoint endpoint-id nil nil {:gateway-url "http://localhost"})))
 
 (deftest test-validate-correct
   (is (= {:status status/ok :body {:valid true}}
@@ -59,9 +59,9 @@
 (deftest check-endpoint-forwards-path
   (let [captured (atom nil)
         endpoint-id "google.com"]
-    (with-redefs [validate/check-endpoint (fn [eid path _config]
+    (with-redefs [validate/check-endpoint (fn [eid path _oaepi-version _config]
                                             (reset! captured {:endpoint eid :path path})
                                             {:status status/ok
                                              :body   (json/write-str {:gateway {:endpoints {(keyword eid) {:responseCode status/ok}}}})})]
-      (checker/check-endpoint endpoint-id "/programs" {:gateway-url "http://localhost"})
+      (checker/check-endpoint endpoint-id "/programs" nil {:gateway-url "http://localhost"})
       (is (= {:endpoint endpoint-id :path "/programs"} @captured)))))

--- a/test/nl/surf/eduhub/validator/service/config_test.clj
+++ b/test/nl/surf/eduhub/validator/service/config_test.clj
@@ -28,7 +28,6 @@
                   :gateway-basic-auth-pass            "default",
                   :gateway-url                        "https://gateway.test.surfeduhub.nl/",
                   :max-total-requests                 "5",
-                  :ooapi-version                      "default",
                   :redis-uri                          "redis://example.com"
                   :surf-conext-client-id              "default",
                   :surf-conext-client-secret          "default",
@@ -40,7 +39,6 @@
 (def default-expected-value
   {:allowed-client-ids         "default",
    :gateway-url                "https://gateway.test.surfeduhub.nl/",
-   :ooapi-version              "default",
    :check-endpoint-path        "/courses",
    :gateway-basic-auth         {:pass "default", :user "john200"},
    :introspection-basic-auth   {:pass "default", :user "default"},

--- a/test/nl/surf/eduhub/validator/service/validate_test.clj
+++ b/test/nl/surf/eduhub/validator/service/validate_test.clj
@@ -45,7 +45,6 @@
       (let [opts {:basic-auth         gateway-basic-auth
                   :base-url           gateway-url
                   :max-total-requests max-total-requests
-                  :ooapi-version      5
                   :profile            "rio"
                   :runtime-extra      {"RuntimeExtra" "Test"}}
             report (validate/validate-endpoint "demo04.test.surfeduhub.nl" opts)]
@@ -60,19 +59,18 @@
   (let [captured   (atom nil)
         base-config {:gateway-url                "https://gateway.test.surfeduhub.nl"
                      :gateway-basic-auth         {:user "u" :pass "p"}
-                     :ooapi-version              "5"
                      :check-endpoint-path        "/courses"}]
     (with-redefs [http/get (fn [url opts]
                              (reset! captured {:url url :opts opts})
                              {:status 200 :body ""})]
       (reset! captured nil)
-      (validate/check-endpoint "endpoint.test" nil base-config)
+      (validate/check-endpoint "endpoint.test" nil "5" base-config)
       (is (= "https://gateway.test.surfeduhub.nl/courses" (:url @captured)))
 
       (reset! captured nil)
-      (validate/check-endpoint "endpoint.test" nil (assoc base-config :check-endpoint-path "/programs"))
+      (validate/check-endpoint "endpoint.test" nil "6" (assoc base-config :check-endpoint-path "/programs"))
       (is (= "https://gateway.test.surfeduhub.nl/programs" (:url @captured)))
 
       (reset! captured nil)
-      (validate/check-endpoint "endpoint.test" "/custom/123" base-config)
+      (validate/check-endpoint "endpoint.test" "/custom/123" nil base-config)
       (is (= "https://gateway.test.surfeduhub.nl/custom/123" (:url @captured))))))


### PR DESCRIPTION
1. Bump the eduhub-validator version to include the latest v6 profiles

2. Remove "OOAPI_VERSION" environment config option; validation profiles now include the correct Accept header info

2. Add a required `oeapi-version` query parameter to the `check-endpoint` apie call, since that call is done without a profile